### PR TITLE
Create output yml file if it doesn't exist instead of raising FileNotFoundError

### DIFF
--- a/possum/cli.py
+++ b/possum/cli.py
@@ -288,7 +288,7 @@ def main():
         logger.info("Writing deployment template to "
                     f"'{args.output_template}'...\n")
         with open(os.path.join(WORKING_DIR, args.output_template),
-                  'wt') as fobj:
+                  'w+') as fobj:
             fobj.write(deployment_template)
 
     possum_file.save()


### PR DESCRIPTION
If you attempt to run `possum` with an output file that doesn't exist you get a `FileNotFoundError`.

```
$ possum 'my-deploy-bucket' -o deploy.yml                                                 
ERROR: Failed to load template file! Encountered: FileNotFoundError
```

Open the file in the `w+` mode to create the missing file.